### PR TITLE
WIP: Add error message and docs for PintBlueprint

### DIFF
--- a/quart_openapi/pint.py
+++ b/quart_openapi/pint.py
@@ -457,6 +457,8 @@ class PintBlueprint(BaseRest, Blueprint):
         """override the base :meth:`~quart.Blueprint.register` method to add the resources to the app registering
         this blueprint, then call the parent register method
         """
+        if not isinstance(app, Pint):
+            raise TypeError(f"Please use PintBlueprint with instance of Pint not {type(app)}")
         prefix = url_prefix or self.url_prefix or ''
         app._resources.extend([(res, f'{prefix}{path}', methods) for res, path, methods in self._resources])
         super().register(app, first_registration, url_prefix=url_prefix)


### PR DESCRIPTION
Spent some time trying to use `PintBlueprint` with `Quart` instead of `Pint`, so thought I'd add this error message to help others out who might make this same mistake.

Would also be interested in extending the docs for `PintBlueprint`, hence the WIP tag, please let me know if that would be welcome.