### PR TITLE
Update documentation

### DIFF
--- a/docs/pint.rst
+++ b/docs/pint.rst
@@ -3,10 +3,24 @@
 .. currentmodule:: quart_openapi
 
 Pint Class
-=============
+==========
 
 .. autoclass:: Pint
-   :members:
+   :members: handle_json_validation_exc, resources, base_model, get_validator, param,
+             response, route, create_ref_validator, create_validator, doc, expect,
+             default_id
+   :show-inheritance:
+
+   .. automethod:: __init__
+
+
+PintBlueprint Class
+===================
+
+.. autoclass:: PintBlueprint
+   :members: handle_json_validation_exc, resources, base_model, get_validator, param,
+             response, route, create_ref_validator, create_validator, doc, expect,
+             default_id, register
    :show-inheritance:
 
    .. automethod:: __init__

--- a/docs/pint.rst
+++ b/docs/pint.rst
@@ -11,10 +11,10 @@ Pint Class
 
    .. automethod:: __init__
 
-SwaggerView helper
+OpenApiView helper
 ------------------
 
-.. autoclass:: SwaggerView
+.. autoclass:: OpenApiView
    :members:
    :inherited-members:
    :show-inheritance:

--- a/quart_openapi/typing.py
+++ b/quart_openapi/typing.py
@@ -2,7 +2,8 @@ from typing import Union, Tuple, Iterable, Dict, Any, Type
 from jsonschema import Draft4Validator
 
 PyTypes = Union[Type[int], Type[float], Type[str], Type[bool]]
-ValidatorTypes = Union[PyTypes, str, Draft4Validator, Iterable['ValidatorTypes']]
+ValidatorType = Union[PyTypes, str, Draft4Validator]
+ValidatorTypes = Union[ValidatorType, Iterable['ValidatorType']]
 ExpectedDescList = Union[ValidatorTypes, Tuple[ValidatorTypes], Tuple[ValidatorTypes, str],
                          Tuple[ValidatorTypes, str, Dict[str, Any]]]
 HeaderType = Union[PyTypes, str, Iterable[PyTypes], Draft4Validator, Dict[str, Any]]


### PR DESCRIPTION
Thanks for `quart-openapi`! I noticed that the documentation at https://factset.github.io/quart-openapi/ was missing for nearly all of the methods in `pint.py`. This PR addresses that in three ways:

1. Using the correct class name for `OpenApiView` instead of the outdated `SwaggerView`.
1. Explicitly specifying and rendering the 'hidden' methods in `Pint` and `PintBlueprint` due their importing `BaseRest` even though `BaseRest` is not imported in `__init__.py` (meaning it can't be directly `autodoc`'d by Sphinx).
1. Un-recursiving one of the types in `typing.py`. Without this, Sphinx dies with a recursion error when trying to render `response()`.

Let me know if you need anything done to make this PR fit your standards (or feel free to push up commits yourself if GitHub lets you). In particular, we may want to move from specifying members directly and using `:inherited-members:`, showing all the members of `Quart` in the process.

Thanks!