### PR TITLE
Unpin jsonschema

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,3 +1,3 @@
-jsonschema == 2.6.0
+jsonschema
 quart >= 0.6.0, < 0.7.0;python_version<"3.7"
 quart >= 0.7.0;python_version>="3.7"


### PR DESCRIPTION
In https://github.com/factset/quart-openapi/pull/10, `jsonschema` was pinned in order to prevent the roll to 3.x.x which was still in alpha. It's been out of alpha for a while now, so this PR unpins the dependency. I'm not sure about any breaking changes, as the tests still seem to pass. Feel free to adopt/rewrite this PR if there are things I've missed, thanks!